### PR TITLE
Use rustls by default and add feature for native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,17 @@ jsonwebtoken = "8.3.0"
 actix-web = "4.3.1"
 futures-util = "0.3.28"
 actix-rt = "2.9.0"
+
 [dependencies.reqwest]
 version = "^0.11"
+default-features = false
 features = ["json", "multipart"]
 
 [dev-dependencies]
 clerk-rs = { path = "../clerk-rs" }
 tokio = { version = "1.27.0", features = ["full"] }
+
+[features]
+default = ["rustls-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]


### PR DESCRIPTION
This PR adds `rustls-tls` and `native-tls` feature flags and changes the default to be `rustls-tls`.

Closes #33.