### PR TITLE
Remove dependency on openssl in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,8 @@ features = ["json", "multipart"]
 [dev-dependencies]
 base64 = "0.22.1"
 clerk-rs = { path = "../clerk-rs" }
-openssl = "0.10.64"
+rand = "0.8.5"
+rsa = "0.9.6"
 tokio = { version = "1.27.0", features = ["full"] }
 
 [features]


### PR DESCRIPTION
This PR replaces `openssl` with the `rng` and `rand` crates which don't require additional dependencies.