### PR TITLE
Add feature flags for axum and actix validators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,12 @@ path = "examples/api.rs"
 [[example]]
 name = "actix"
 path = "examples/actix.rs"
+required-features = ["actix"]
 
 [[example]]
 name = "axum"
 path = "examples/axum.rs"
+required-features = ["axum"]
 
 [lib]
 doctest = false
@@ -38,10 +40,10 @@ regex = "1.7.3"
 jsonwebtoken = "8.3.0"
 actix-web = "4.3.1"
 futures-util = "0.3.28"
-actix-rt = "2.9.0"
-axum = "0.7.5"
-axum-extra = { version = "0.9.3", features = ["cookie"] }
-tower = "0.4.13"
+actix-rt = { version = "2.9.0", optional = true }
+axum = { version = "0.7.5", optional = true }
+axum-extra = { version = "0.9.3", features = ["cookie"], optional = true }
+tower = { version = "0.4.13", optional = true }
 
 [dependencies.reqwest]
 version = "^0.11"
@@ -58,3 +60,5 @@ tokio = { version = "1.27.0", features = ["full"] }
 default = ["rustls-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+actix = ["dep:actix-rt"]
+axum = ["dep:axum", "dep:axum-extra", "dep:tower"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more detailed documentation, please reference the below links:
 
 > This SDK is updated frequently to keep up with any changes to the actual Clerk API. If you see anything that needs updated or is not inline with the official Clerk api, please open an issue!
 
-## Example
+## Examples
 
 > Checkout examples in the `/examples` directory
 
@@ -55,6 +55,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Protecting a actix-web endpoint with Clerk.dev:
 
+With the `actix` feature enabled:
+
 ```rust
 use actix_web::{web, App, HttpServer, Responder};
 use clerk_rs::{validators::actix::ClerkMiddleware, ClerkConfiguration};
@@ -78,6 +80,8 @@ async fn main() -> std::io::Result<()> {
 ```
 
 ### Protecting a axum endpoint with Clerk.dev:
+
+With the `axum` feature enabled:
 
 ```rust
 use axum::{routing::get, Router};

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -1,4 +1,7 @@
 // Validators for Rocket, etc coming very soon
-pub mod actix;
 pub mod authorizer;
+
+#[cfg(feature = "actix")]
+pub mod actix;
+#[cfg(feature = "axum")]
 pub mod axum;


### PR DESCRIPTION
This PR adds `axum` and `actix` feature flags that enable the Axum and Actix validators respectively. This is breaking since the `actix` validator is no longer available by default.

Closes #37.