### PR TITLE
Validate the nbf claim of the jwt

### DIFF
--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -109,6 +109,7 @@ pub fn validate_jwt(token: &str, jwks: JwksModel) -> Result<(bool, ClerkJwt), bo
 				let decoding_key = DecodingKey::from_rsa_components(&j.n, &j.e).unwrap();
 				let mut validation = Validation::new(Algorithm::RS256);
 				validation.validate_exp = true;
+				validation.validate_nbf = true;
 
 				return match decode::<ClerkJwt>(&token, &decoding_key, &validation) {
 					Ok(token) => Ok((true, token.claims)),


### PR DESCRIPTION
This PR enables `validate_nbf` on `jsonwebtoken::Validation` per the [Clerk docs](https://clerk.com/docs/backend-requests/handling/manual-jwt#verify-the-token-signature).