### PR TITLE
Remove panics and return ClerkError from validate_jwt

### DIFF
--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -264,7 +264,6 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic]
 	fn test_validate_jwt_missing_token_kid() {
 		let helper = Helper::new();
 
@@ -284,7 +283,7 @@ mod tests {
 
 		let token = helper.generate_jwt_token(None, None, false);
 
-		let _ = validate_jwt(token.as_str(), jwks);
+		assert!(matches!(validate_jwt(&token, jwks), Err(ClerkError::Unauthorized(_))))
 	}
 
 	#[test]
@@ -312,7 +311,6 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic]
 	fn test_validate_jwt_unexpected_key_algorithm() {
 		let helper = Helper::new();
 
@@ -332,11 +330,10 @@ mod tests {
 
 		let token = helper.generate_jwt_token(Some(kid), None, false);
 
-		let _ = validate_jwt(token.as_str(), jwks);
+		assert!(matches!(validate_jwt(&token, jwks), Err(ClerkError::InternalServerError(_))))
 	}
 
 	#[test]
-	#[should_panic]
 	fn test_validate_jwt_invalid_decoding_key() {
 		let helper = Helper::new();
 
@@ -354,7 +351,7 @@ mod tests {
 
 		let token = helper.generate_jwt_token(Some(kid), None, false);
 
-		let _ = validate_jwt(token.as_str(), jwks);
+		assert!(matches!(validate_jwt(&token, jwks), Err(ClerkError::InternalServerError(_))))
 	}
 
 	#[test]

--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -103,7 +103,8 @@ pub fn validate_jwt(token: &str, jwks: JwksModel) -> Result<ClerkJwt, ClerkError
 		match j.alg.as_str() {
 			// Currently, clerk only supports Rs256 by default
 			"RS256" => {
-				let decoding_key = DecodingKey::from_rsa_components(&j.n, &j.e).unwrap();
+				let decoding_key = DecodingKey::from_rsa_components(&j.n, &j.e)
+					.map_err(|_| ClerkError::InternalServerError(String::from("Error: Invalid decoding key")))?;
 				let mut validation = Validation::new(Algorithm::RS256);
 				validation.validate_exp = true;
 				validation.validate_nbf = true;

--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -116,7 +116,7 @@ pub fn validate_jwt(token: &str, jwks: JwksModel) -> Result<(bool, ClerkJwt), bo
 					_ => Err(false),
 				};
 			}
-			_ => unreachable!("This should be a RSA"),
+			_ => return Err(false),
 		}
 	// In the event that a matching jwk was not found we want to output an error
 	} else {

--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -92,14 +92,14 @@ impl ClerkAuthorizer {
 /// Validates a jwt token using a jwks
 pub fn validate_jwt(token: &str, jwks: JwksModel) -> Result<(bool, ClerkJwt), bool> {
 	// If we were not able to parse the kid field we want to output an invalid case...
-	let kid = match get_token_header(token) {
-		Ok(val) => val.kid,
-		Err(_) => {
+	let kid = match get_token_header(token).map(|h| h.kid) {
+		Ok(Some(kid)) => kid,
+		_ => {
 			return Err(false);
 		}
 	};
 
-	let jwk = jwks.keys.iter().find(|k| &k.kid == kid.as_ref().unwrap());
+	let jwk = jwks.keys.iter().find(|k| k.kid == kid);
 
 	// Check to see if we found a valid jwk key with the token kid
 	if let Some(j) = jwk {


### PR DESCRIPTION
This PR replaces some potential panics in `validate_jwt` with errors and changes the signature of `validate_jwt` to return `Result<Jwt, Error>` instead of `Result<(bool, Jwt), bool>`.