### PR TITLE
Make actix-web dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ serde_json = "^1.0"
 url = "^2.2"
 regex = "1.7.3"
 jsonwebtoken = "8.3.0"
-actix-web = "4.3.1"
 futures-util = "0.3.28"
 actix-rt = { version = "2.9.0", optional = true }
+actix-web = { version = "4.3.1", optional = true }
 axum = { version = "0.7.5", optional = true }
 axum-extra = { version = "0.9.3", features = ["cookie"], optional = true }
 tower = { version = "0.4.13", optional = true }
@@ -61,5 +61,5 @@ tokio = { version = "1.27.0", features = ["full"] }
 default = ["rustls-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
-actix = ["dep:actix-rt"]
+actix = ["dep:actix-rt", "dep:actix-web"]
 axum = ["dep:axum", "dep:axum-extra", "dep:tower"]


### PR DESCRIPTION
This PR makes the `actix-web` crate optional and adds it to the `actix` feature. Somehow missed it in #39.