### PR TITLE
Add JwksProvider to allow for caching of the JWKS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ features = ["json", "multipart"]
 [dev-dependencies]
 base64 = "0.22.1"
 clerk-rs = { path = "../clerk-rs" }
+mockito = "1.4.0"
 rand = "0.8.5"
 rsa = "0.9.6"
 tokio = { version = "1.39.3", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ actix-web = { version = "4.9.0", optional = true }
 axum = { version = "0.7.5", optional = true }
 axum-extra = { version = "0.9.3", features = ["cookie"], optional = true }
 tower = { version = "0.5.0", optional = true }
+async-trait = "0.1.81"
+arc-swap = "1.7.1"
 
 [dependencies.reqwest]
 version = "^0.12"

--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ With the `axum` feature enabled:
 
 ```rust
 use axum::{routing::get, Router};
-use clerk_rs::validators::axum::ClerkLayer;
-use clerk_rs::ClerkConfiguration;
-use std::net::SocketAddr;
+use clerk_rs::{
+    clerk::Clerk,
+    validators::{axum::ClerkLayer, jwks::MemoryCacheJwksProvider},
+    ClerkConfiguration,
+};
 
 async fn index() -> &'static str {
     "Hello world!"
@@ -91,10 +93,14 @@ async fn index() -> &'static str {
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    let config: ClerkConfiguration = ClerkConfiguration::new(None, None, Some("your_secret_key".to_string()), None);
-    let app = Router::new().route("/index", get(index)).layer(ClerkLayer::new(config, None, true));
-    let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
-    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let config = ClerkConfiguration::new(None, None, Some("your_secret_key".to_string()), None);
+    let clerk = Clerk::new(config);
+
+    let app = Router::new()
+        .route("/index", get(index))
+        .layer(ClerkLayer::new(MemoryCacheJwksProvider::new(clerk), None, true));
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
     axum::serve(listener, app).await
 }
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ With the `actix` feature enabled:
 
 ```rust
 use actix_web::{web, App, HttpServer, Responder};
-use clerk_rs::{validators::actix::ClerkMiddleware, ClerkConfiguration};
+use clerk_rs::{
+    clerk::Clerk,
+    validators::{actix::ClerkMiddleware, jwks::MemoryCacheJwksProvider},
+    ClerkConfiguration,
+};
 
 async fn index() -> impl Responder {
     "Hello world!"
@@ -65,8 +69,10 @@ async fn index() -> impl Responder {
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
         let config = ClerkConfiguration::new(None, None, Some("your_secret_key".to_string()), None);
+        let clerk = Clerk::new(config);
+
         App::new()
-            .wrap(ClerkMiddleware::new(config, None, true))
+            .wrap(ClerkMiddleware::new(MemoryCacheJwksProvider::new(clerk), None, true))
             .route("/index", web::get().to(index))
     })
     .bind(("127.0.0.1", 8080))?

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -1,5 +1,9 @@
 use actix_web::{web, App, HttpServer, Responder};
-use clerk_rs::{validators::actix::ClerkMiddleware, ClerkConfiguration};
+use clerk_rs::{
+	clerk::Clerk,
+	validators::{actix::ClerkMiddleware, jwks::MemoryCacheJwksProvider},
+	ClerkConfiguration,
+};
 
 async fn index() -> impl Responder {
 	"Hello world!"
@@ -9,8 +13,10 @@ async fn index() -> impl Responder {
 async fn main() -> std::io::Result<()> {
 	HttpServer::new(|| {
 		let config = ClerkConfiguration::new(None, None, Some("your_secret_key".to_string()), None);
+		let clerk = Clerk::new(config);
+
 		App::new()
-			.wrap(ClerkMiddleware::new(config, None, true))
+			.wrap(ClerkMiddleware::new(MemoryCacheJwksProvider::new(clerk), None, true))
 			.route("/index", web::get().to(index))
 	})
 	.bind(("127.0.0.1", 8080))?

--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -77,7 +77,6 @@ impl fmt::Display for ClerkError {
 
 impl Error for ClerkError {}
 
-#[derive(Clone)]
 pub struct ClerkAuthorizer<J> {
 	jwks_provider: Arc<J>,
 	validate_session_cookie: bool,
@@ -118,6 +117,15 @@ impl<J: JwksProvider> ClerkAuthorizer<J> {
 		};
 
 		validate_jwt(&access_token, self.jwks_provider.clone()).await
+	}
+}
+
+impl<J> Clone for ClerkAuthorizer<J> {
+	fn clone(&self) -> Self {
+		Self {
+			jwks_provider: self.jwks_provider.clone(),
+			validate_session_cookie: self.validate_session_cookie,
+		}
 	}
 }
 

--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -1,10 +1,7 @@
-use crate::{
-	apis::jwks_api::{Jwks, JwksModel},
-	clerk::Clerk,
-};
+use crate::{apis::jwks_api::JwksKey, validators::jwks::JwksProvider};
 use jsonwebtoken::{decode, decode_header, errors::Error as jwtError, Algorithm, DecodingKey, Header, Validation};
 use serde_json::{Map, Value};
-use std::{error::Error, fmt};
+use std::{error::Error, fmt, sync::Arc};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ActiveOrganization {
@@ -81,16 +78,16 @@ impl fmt::Display for ClerkError {
 impl Error for ClerkError {}
 
 #[derive(Clone)]
-pub struct ClerkAuthorizer {
-	clerk_client: Clerk,
+pub struct ClerkAuthorizer<J> {
+	jwks_provider: Arc<J>,
 	validate_session_cookie: bool,
 }
 
-impl ClerkAuthorizer {
+impl<J: JwksProvider> ClerkAuthorizer<J> {
 	/// Creates a Clerk authorizer
-	pub fn new(clerk_client: Clerk, validate_session_cookie: bool) -> Self {
+	pub fn new(jwks_provider: J, validate_session_cookie: bool) -> Self {
 		Self {
-			clerk_client,
+			jwks_provider: Arc::new(jwks_provider),
 			validate_session_cookie,
 		}
 	}
@@ -100,11 +97,7 @@ impl ClerkAuthorizer {
 	where
 		T: ClerkRequest,
 	{
-		let jwks = match Jwks::get_jwks(&self.clerk_client).await {
-			Ok(val) => val,
-			Err(_) => return Err(ClerkError::InternalServerError(String::from("Error: Could not fetch JWKS!"))),
-		};
-
+		// get the jwt from header or cookies
 		let access_token: String = match request.get_header("Authorization") {
 			Some(val) => val.to_string().replace("Bearer ", ""),
 			None => match self.validate_session_cookie {
@@ -124,43 +117,52 @@ impl ClerkAuthorizer {
 			},
 		};
 
-		validate_jwt(&access_token, jwks)
+		validate_jwt(&access_token, self.jwks_provider.clone()).await
 	}
 }
 
-/// Validates a jwt token using a jwks
-pub fn validate_jwt(token: &str, jwks: JwksModel) -> Result<ClerkJwt, ClerkError> {
-	// If we were not able to parse the kid field we want to output an invalid case...
+/// Validates a jwt using the given [`JwksProvider`].
+///
+/// The jwt is required to have a `kid` which is used to request the matching key from the provider.
+pub async fn validate_jwt<J: JwksProvider>(token: &str, jwks: Arc<J>) -> Result<ClerkJwt, ClerkError> {
+	// parse the header to get the kid
 	let kid = match get_token_header(token).map(|h| h.kid) {
 		Ok(Some(kid)) => kid,
 		_ => {
+			// if the kid header was invalid or the kid field was unset, error
 			return Err(ClerkError::Unauthorized(String::from("Error: Invalid JWT!")));
 		}
 	};
 
-	let jwk = jwks.keys.iter().find(|k| k.kid == kid);
-
-	// Check to see if we found a valid jwk key with the token kid
-	if let Some(j) = jwk {
-		match j.alg.as_str() {
-			// Currently, clerk only supports Rs256 by default
-			"RS256" => {
-				let decoding_key = DecodingKey::from_rsa_components(&j.n, &j.e)
-					.map_err(|_| ClerkError::InternalServerError(String::from("Error: Invalid decoding key")))?;
-				let mut validation = Validation::new(Algorithm::RS256);
-				validation.validate_exp = true;
-				validation.validate_nbf = true;
-
-				match decode::<ClerkJwt>(token, &decoding_key, &validation) {
-					Ok(token) => Ok(token.claims),
-					Err(err) => Err(ClerkError::Unauthorized(format!("Error: Invalid JWT! cause: {}", err))),
-				}
-			}
-			_ => Err(ClerkError::InternalServerError(String::from("Error: Unsupported key algorithm"))),
-		}
-	} else {
+	// get the key from the provider
+	let Ok(key) = jwks.get_key(&kid).await else {
 		// In the event that a matching jwk was not found we want to output an error
-		Err(ClerkError::Unauthorized(String::from("Error: Invalid JWT!")))
+		return Err(ClerkError::Unauthorized(String::from("Error: Invalid JWT!")));
+	};
+
+	validate_jwt_with_key(token, &key)
+}
+
+/// Validates a jwt using the given jwk.
+///
+/// This function does not check that the token's kid matches the key's.
+pub fn validate_jwt_with_key(token: &str, key: &JwksKey) -> Result<ClerkJwt, ClerkError> {
+	match key.alg.as_str() {
+		// Currently, clerk only supports Rs256 by default
+		"RS256" => {
+			let decoding_key = DecodingKey::from_rsa_components(&key.n, &key.e)
+				.map_err(|_| ClerkError::InternalServerError(String::from("Error: Invalid decoding key")))?;
+
+			let mut validation = Validation::new(Algorithm::RS256);
+			validation.validate_exp = true;
+			validation.validate_nbf = true;
+
+			match decode::<ClerkJwt>(token, &decoding_key, &validation) {
+				Ok(token) => Ok(token.claims),
+				Err(err) => Err(ClerkError::Unauthorized(format!("Error: Invalid JWT! cause: {}", err))),
+			}
+		}
+		_ => Err(ClerkError::InternalServerError(String::from("Error: Unsupported key algorithm"))),
 	}
 }
 
@@ -173,7 +175,7 @@ fn get_token_header(token: &str) -> Result<Header, jwtError> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::apis::jwks_api::JwksKey;
+	use crate::{apis::jwks_api::JwksKey, validators::jwks::tests::StaticJwksProvider};
 	use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 	use base64::prelude::*;
 	use jsonwebtoken::{encode, errors::ErrorKind, Algorithm, EncodingKey, Header};
@@ -220,12 +222,15 @@ mod tests {
 			let pem = self.private_key.to_pkcs1_pem(rsa::pkcs8::LineEnding::LF).unwrap();
 			let encoding_key = EncodingKey::from_rsa_pem(pem.as_bytes()).expect("Failed to load encoding key");
 
-			let current_time = current_time.unwrap_or(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as usize);
+			let mut current_time = current_time.unwrap_or(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as usize);
 
-			let mut expiration = current_time;
-			if !expired {
-				expiration += 3600;
+			if expired {
+				// issue the token some time in the past so that it's expired now
+				current_time -= 5000;
 			}
+
+			// expire after 1000 secs
+			let expiration = current_time + 1000;
 
 			let claims = Claims {
 				azp: "client_id".to_string(),
@@ -268,7 +273,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_validate_jwt_success() {
+	fn test_validate_jwt_with_key_success() {
 		let helper = Helper::new();
 
 		let kid = "bc63c2e9-5d1c-4e32-9b62-178f60409abd";
@@ -283,7 +288,6 @@ mod tests {
 			n: modulus,
 			e: exponent,
 		};
-		let jwks = JwksModel { keys: vec![jwks_key] };
 
 		let current_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as usize;
 		let token = helper.generate_jwt_token(Some(kid), Some(current_time), false);
@@ -292,7 +296,7 @@ mod tests {
 			azp: Some("client_id".to_string()),
 			sub: "user".to_string(),
 			iat: current_time as i32,
-			exp: (current_time + 3600) as i32,
+			exp: (current_time + 1000) as i32,
 			iss: "issuer".to_string(),
 			nbf: current_time as i32,
 			sid: Some("session_id".to_string()),
@@ -322,16 +326,11 @@ mod tests {
 			},
 		};
 
-		match validate_jwt(token.as_str(), jwks) {
-			Ok(jwt) => {
-				assert_eq!(jwt, expected)
-			}
-			Err(_) => unreachable!("Unexpected invalid jwt token"),
-		}
+		assert_eq!(validate_jwt_with_key(token.as_str(), &jwks_key).expect("should be valid"), expected);
 	}
 
 	#[test]
-	fn test_validate_jwt_error_getting_token_header() {
+	fn test_validate_jwt_with_key_unexpected_key_algorithm() {
 		let helper = Helper::new();
 
 		let kid = "bc63c2e9-5d1c-4e32-9b62-178f60409abd";
@@ -342,90 +341,21 @@ mod tests {
 			use_key: String::new(),
 			kty: String::new(),
 			kid: kid.to_string(),
-			alg: String::from("RS256"),
+			alg: String::from("INVALIDALGORITHM"),
 			n: modulus,
 			e: exponent,
 		};
-		let jwks = JwksModel { keys: vec![jwks_key] };
-
-		match validate_jwt("invalid_token", jwks) {
-			Ok(_) => unreachable!("Unexpected valid jwt token"),
-			Err(_) => assert!(true),
-		}
-	}
-
-	#[test]
-	fn test_validate_jwt_missing_token_kid() {
-		let helper = Helper::new();
-
-		let kid = "bc63c2e9-5d1c-4e32-9b62-178f60409abd";
-
-		let (modulus, exponent) = helper.get_modulus_and_public_exponent();
-
-		let jwks_key = JwksKey {
-			use_key: String::new(),
-			kty: String::new(),
-			kid: kid.to_string(),
-			alg: String::from("RS256"),
-			n: modulus,
-			e: exponent,
-		};
-		let jwks = JwksModel { keys: vec![jwks_key] };
-
-		let token = helper.generate_jwt_token(None, None, false);
-
-		assert!(matches!(validate_jwt(&token, jwks), Err(ClerkError::Unauthorized(_))))
-	}
-
-	#[test]
-	fn test_validate_jwt_unmatched_jwks_key() {
-		let helper = Helper::new();
-
-		let (modulus, exponent) = helper.get_modulus_and_public_exponent();
-
-		let jwks_key = JwksKey {
-			use_key: String::new(),
-			kty: String::new(),
-			kid: String::from("a288cbf5-fec1-41e3-ae83-5b0d122bf925"),
-			alg: String::from("RS256"),
-			n: modulus,
-			e: exponent,
-		};
-		let jwks = JwksModel { keys: vec![jwks_key] };
-
-		let token = helper.generate_jwt_token(Some("bc63c2e9-5d1c-4e32-9b62-178f60409abd"), None, false);
-
-		match validate_jwt(token.as_str(), jwks) {
-			Ok(_) => unreachable!("Unexpected valid jwt token"),
-			Err(_) => assert!(true),
-		}
-	}
-
-	#[test]
-	fn test_validate_jwt_unexpected_key_algorithm() {
-		let helper = Helper::new();
-
-		let kid = "bc63c2e9-5d1c-4e32-9b62-178f60409abd";
-
-		let (modulus, exponent) = helper.get_modulus_and_public_exponent();
-
-		let jwks_key = JwksKey {
-			use_key: String::new(),
-			kty: String::new(),
-			kid: kid.to_string(),
-			alg: String::from("ES256"),
-			n: modulus,
-			e: exponent,
-		};
-		let jwks = JwksModel { keys: vec![jwks_key] };
 
 		let token = helper.generate_jwt_token(Some(kid), None, false);
 
-		assert!(matches!(validate_jwt(&token, jwks), Err(ClerkError::InternalServerError(_))))
+		assert!(matches!(
+			validate_jwt_with_key(&token, &jwks_key),
+			Err(ClerkError::InternalServerError(_))
+		))
 	}
 
 	#[test]
-	fn test_validate_jwt_invalid_decoding_key() {
+	fn test_validate_jwt_with_key_invalid_decoding_key() {
 		let helper = Helper::new();
 
 		let kid = "bc63c2e9-5d1c-4e32-9b62-178f60409abd";
@@ -438,57 +368,213 @@ mod tests {
 			n: String::from("INVALIDMODULUS"),
 			e: String::from("INVALIDEXPONENT"),
 		};
-		let jwks = JwksModel { keys: vec![jwks_key] };
 
 		let token = helper.generate_jwt_token(Some(kid), None, false);
 
-		assert!(matches!(validate_jwt(&token, jwks), Err(ClerkError::InternalServerError(_))))
+		assert!(matches!(
+			validate_jwt_with_key(&token, &jwks_key),
+			Err(ClerkError::InternalServerError(_))
+		))
 	}
 
 	#[test]
-	fn test_validate_jwt_invalid_jwt_token() {
-		let helper = Helper::new();
+	fn test_validate_jwt_with_key_invalid_sig() {
+		let helper1 = Helper::new();
+		let helper2 = Helper::new();
 
 		let kid = "bc63c2e9-5d1c-4e32-9b62-178f60409abd";
+
+		let (modulus, exponent) = helper1.get_modulus_and_public_exponent();
 
 		let jwks_key = JwksKey {
 			use_key: String::new(),
 			kty: String::new(),
 			kid: kid.to_string(),
 			alg: String::from("RS256"),
-			n: String::new(),
-			e: String::new(),
+			n: modulus,
+			e: exponent,
 		};
-		let jwks = JwksModel { keys: vec![jwks_key] };
 
-		let token = helper.generate_jwt_token(Some(kid), None, false);
+		let token = helper2.generate_jwt_token(None, None, false);
 
-		match validate_jwt(token.as_str(), jwks) {
-			Ok(_) => unreachable!("Unexpected valid jwt token"),
-			Err(_) => assert!(true),
-		}
+		let res = validate_jwt_with_key(&token, &jwks_key);
+		assert!(matches!(res, Err(ClerkError::Unauthorized(_))));
 	}
 
 	#[test]
-	fn test_token_kid_success() {
+	fn test_validate_jwt_with_key_expired() {
+		let helper = Helper::new();
+
+		let kid = "bc63c2e9-5d1c-4e32-9b62-178f60409abd";
+
+		let (modulus, exponent) = helper.get_modulus_and_public_exponent();
+
+		let jwks_key = JwksKey {
+			use_key: String::new(),
+			kty: String::new(),
+			kid: kid.to_string(),
+			alg: String::from("RS256"),
+			n: modulus,
+			e: exponent,
+		};
+
+		let token = helper.generate_jwt_token(Some(kid), None, true);
+
+		let res = validate_jwt_with_key(&token, &jwks_key);
+		assert!(matches!(res, Err(ClerkError::Unauthorized(_))))
+	}
+
+	#[tokio::test]
+	async fn test_validate_jwt_success() {
+		let helper = Helper::new();
+
+		let kid = "bc63c2e9-5d1c-4e32-9b62-178f60409abd";
+
+		let (modulus, exponent) = helper.get_modulus_and_public_exponent();
+
+		let jwks_key = JwksKey {
+			use_key: String::new(),
+			kty: String::new(),
+			kid: kid.to_string(),
+			alg: String::from("RS256"),
+			n: modulus,
+			e: exponent,
+		};
+		let jwks = Arc::new(StaticJwksProvider::from_key(jwks_key));
+
+		let current_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as usize;
+		let token = helper.generate_jwt_token(Some(kid), Some(current_time), false);
+
+		let expected = ClerkJwt {
+			azp: Some("client_id".to_string()),
+			sub: "user".to_string(),
+			iat: current_time as i32,
+			exp: (current_time + 1000) as i32,
+			iss: "issuer".to_string(),
+			nbf: current_time as i32,
+			sid: Some("session_id".to_string()),
+			act: Some(Actor {
+				iss: "actor_iss".to_string(),
+				sid: Some("actor_sid".to_string()),
+				sub: "actor_sub".to_string(),
+			}),
+			org: Some(ActiveOrganization {
+				id: "org_id".to_string(),
+				slug: "org_slug".to_string(),
+				role: "org_role".to_string(),
+				permissions: vec!["org_permission".to_string()],
+			}),
+			other: {
+				let mut map = Map::new();
+				map.insert("custom_key".to_string(), Value::String("custom_value".to_string()));
+				map.insert(
+					"custom_map".to_string(),
+					Value::Object({
+						let mut map = Map::new();
+						map.insert("custom_attribute".to_string(), Value::String("custom_attribute".to_string()));
+						map
+					}),
+				);
+				map
+			},
+		};
+
+		assert_eq!(validate_jwt(token.as_str(), jwks).await.expect("should be valid"), expected);
+	}
+
+	#[tokio::test]
+	async fn test_validate_jwt_invalid_token() {
+		let helper = Helper::new();
+
+		let kid = "bc63c2e9-5d1c-4e32-9b62-178f60409abd";
+
+		let (modulus, exponent) = helper.get_modulus_and_public_exponent();
+
+		let jwks_key = JwksKey {
+			use_key: String::new(),
+			kty: String::new(),
+			kid: kid.to_string(),
+			alg: String::from("RS256"),
+			n: modulus,
+			e: exponent,
+		};
+		let jwks = Arc::new(StaticJwksProvider::from_key(jwks_key));
+
+		assert!(matches!(validate_jwt("invalid_token", jwks).await, Err(ClerkError::Unauthorized(_))))
+	}
+
+	#[tokio::test]
+	async fn test_validate_jwt_missing_kid() {
+		let helper = Helper::new();
+
+		let kid = "bc63c2e9-5d1c-4e32-9b62-178f60409abd";
+
+		let (modulus, exponent) = helper.get_modulus_and_public_exponent();
+
+		let jwks_key = JwksKey {
+			use_key: String::new(),
+			kty: String::new(),
+			kid: kid.to_string(),
+			alg: String::from("RS256"),
+			n: modulus,
+			e: exponent,
+		};
+		let jwks = Arc::new(StaticJwksProvider::from_key(jwks_key));
+
+		let token = helper.generate_jwt_token(None, None, false);
+
+		assert!(matches!(validate_jwt(&token, jwks).await, Err(ClerkError::Unauthorized(_))))
+	}
+
+	#[tokio::test]
+	async fn test_validate_jwt_unknown_key() {
+		let helper = Helper::new();
+
+		let (modulus, exponent) = helper.get_modulus_and_public_exponent();
+
+		let jwks_key = JwksKey {
+			use_key: String::new(),
+			kty: String::new(),
+			kid: String::from("a288cbf5-fec1-41e3-ae83-5b0d122bf925"),
+			alg: String::from("RS256"),
+			n: modulus,
+			e: exponent,
+		};
+		let jwks = Arc::new(StaticJwksProvider::from_key(jwks_key));
+
+		let token = helper.generate_jwt_token(Some("bc63c2e9-5d1c-4e32-9b62-178f60409abd"), None, false);
+
+		assert!(matches!(validate_jwt(&token, jwks).await, Err(ClerkError::Unauthorized(_))))
+	}
+
+	#[test]
+	fn test_helper_generate_token_header() {
 		let helper = Helper::new();
 
 		let token = helper.generate_jwt_token(None, None, false);
 		let expected = Header::new(Algorithm::RS256);
 
-		match get_token_header(token.as_str()) {
-			Ok(header) => assert_eq!(header, expected),
-			Err(err) => unreachable!("Unexpected error: {:?}", err),
-		}
+		assert_eq!(get_token_header(&token).expect("should be valid"), expected);
 	}
 
 	#[test]
-	fn test_token_kid_error() {
+	fn test_helper_generate_token_header_with_kid() {
+		let helper = Helper::new();
+
+		let kid = "bc63c2e9-5d1c-4e32-9b62-178f60409abd".to_string();
+
+		let token = helper.generate_jwt_token(Some(&kid), None, false);
+		let mut expected = Header::new(Algorithm::RS256);
+		expected.kid = Some(kid);
+
+		assert_eq!(get_token_header(&token).expect("should be valid"), expected);
+	}
+
+	#[test]
+	fn test_helper_generate_token_header_error() {
 		let token = "invalid_jwt_token";
 
-		match get_token_header(token) {
-			Ok(_) => unreachable!("Expected an error, but it succeeded."),
-			Err(err) => assert_eq!(err.kind().to_owned(), ErrorKind::InvalidToken, "Unexpected error: {:?}", err),
-		}
+		let err = get_token_header(token).expect_err("should be invalid");
+		assert_eq!(err.kind().to_owned(), ErrorKind::InvalidToken);
 	}
 }

--- a/src/validators/jwks.rs
+++ b/src/validators/jwks.rs
@@ -1,0 +1,252 @@
+use crate::{
+	apis::jwks_api::{Jwks, JwksKey},
+	clerk::Clerk,
+	validators::authorizer::ClerkError,
+};
+use arc_swap::{ArcSwap, Guard};
+use async_trait::async_trait;
+use std::{
+	collections::HashMap,
+	sync::Arc,
+	time::{Duration, SystemTime},
+};
+
+/// Trait that implements a provider for the JWKS keys, to be used when validating a JWT.
+///
+/// This crate provides two basic implementations of this trait, [`MemoryCacheJwksProvider`] and [`SimpleJwksProvider`].
+/// By implementing `get_key` for your own struct you can customize how the validator fetches keys.
+#[async_trait]
+pub trait JwksProvider {
+	type Error: Into<ClerkError>;
+
+	async fn get_key(&self, kid: &str) -> Result<JwksKey, Self::Error>;
+}
+
+/// Error type used by [`MemoryCacheJwksProvider`] and [`SimpleJwksProvider`].
+#[derive(Debug)]
+pub enum JwksProviderError {
+	UnknownKey,
+	JwksApi,
+}
+
+impl From<JwksProviderError> for ClerkError {
+	fn from(e: JwksProviderError) -> Self {
+		match e {
+			JwksProviderError::UnknownKey => ClerkError::Unauthorized("Error: Invalid JWT!".into()),
+			JwksProviderError::JwksApi => ClerkError::InternalServerError(String::from("Error: Could not fetch JWKS!")),
+		}
+	}
+}
+
+/// A [`JwksProvider`] implementation that doesn't do any caching.
+///
+/// The JWKS is fetched from the Clerk API on every request.
+pub struct SimpleJwksProvider {
+	clerk_client: Clerk,
+}
+
+impl SimpleJwksProvider {
+	pub fn new(clerk_client: Clerk) -> Self {
+		Self { clerk_client }
+	}
+}
+
+#[async_trait]
+impl JwksProvider for SimpleJwksProvider {
+	type Error = JwksProviderError;
+
+	async fn get_key(&self, kid: &str) -> Result<JwksKey, JwksProviderError> {
+		let jwks = Jwks::get_jwks(&self.clerk_client).await.map_err(|_| JwksProviderError::JwksApi)?;
+
+		jwks.keys.into_iter().find(|k| k.kid == kid).ok_or(JwksProviderError::UnknownKey)
+	}
+}
+
+/// Configures how [`MemoryCacheJwksProvider`] handles requests for non-cached keys.
+pub enum RefreshOnUnknown {
+	/// Never attempt to refresh the JWKS when an unknown `kid` is requested.
+	Never,
+	/// Attempt to refresh the JWKS when an unknown `kid` is requested
+	/// if the cached value is older than the given duration.
+	Ratelimit(Duration),
+	/// Always attempt to refresh the JWKS when an unknown `kid` is requested.
+	Always,
+}
+
+/// Options for [`MemoryCacheJwksProvider`].
+pub struct MemoryCacheJwksProviderOptions {
+	/// How long to cache the JWKS for.
+	/// If this is None, the cached JWKS will live forever or until it is replaced due to [`RefreshOnUnknown`].
+	///
+	/// Defaults to 1 hour.
+	pub expire_after: Option<Duration>,
+	/// Configures the behavior of the provider when a `kid` that isn't in the cache is requested.
+	///
+	/// Defaults to refreshing when an unknown `kid` is requested, at most every 5 minutes.
+	pub refresh_on_unknown: RefreshOnUnknown,
+}
+
+impl Default for MemoryCacheJwksProviderOptions {
+	fn default() -> Self {
+		Self {
+			// 1 hour
+			expire_after: Some(Duration::from_secs(60 * 60)),
+			// 5 minutes
+			refresh_on_unknown: RefreshOnUnknown::Ratelimit(Duration::from_secs(60 * 5)),
+		}
+	}
+}
+
+// Internal state for MemoryCacheJwksProvider.
+// The provider holds this struct in an ArcSwap to allow atomically replacing it.
+struct MemoryCacheJwksProviderState {
+	keys: HashMap<String, JwksKey>,
+	last_updated: SystemTime,
+}
+
+impl MemoryCacheJwksProviderState {
+	fn is_uninitialized(&self) -> bool {
+		self.last_updated == SystemTime::UNIX_EPOCH
+	}
+
+	fn is_expired(&self, expire_after: Option<Duration>) -> bool {
+		// if expire_after is None, the cache is never expired
+		let Some(expire_after) = expire_after else { return false };
+
+		let Ok(elapsed) = self.last_updated.elapsed() else {
+			// time went backwards, return expired
+			return true;
+		};
+
+		elapsed >= expire_after
+	}
+}
+
+/// A [`JwksProvider`] implementation that caches keys in memory.
+///
+/// The JWKS is fetched from the Clerk API on the first request or when the cache expires.
+/// Cache behavior can be configured with [`MemoryCacheJwksProviderOptions`].
+pub struct MemoryCacheJwksProvider {
+	clerk_client: Clerk,
+	options: MemoryCacheJwksProviderOptions,
+	state: ArcSwap<MemoryCacheJwksProviderState>,
+}
+
+impl MemoryCacheJwksProvider {
+	/// Creates a new [`MemoryCacheJwksProvider`] with the given client and the default options.
+	pub fn new(clerk_client: Clerk) -> Self {
+		Self::new_with_options(clerk_client, MemoryCacheJwksProviderOptions::default())
+	}
+
+	/// Creates a new [`MemoryCacheJwksProvider`] with the given client and options.
+	pub fn new_with_options(clerk_client: Clerk, options: MemoryCacheJwksProviderOptions) -> Self {
+		let initial_state = MemoryCacheJwksProviderState {
+			keys: HashMap::new(),
+			last_updated: SystemTime::UNIX_EPOCH, // mark uninitialized
+		};
+
+		Self {
+			clerk_client,
+			options,
+			state: ArcSwap::new(Arc::new(initial_state)),
+		}
+	}
+
+	async fn refresh(&self) -> Result<Arc<MemoryCacheJwksProviderState>, JwksProviderError> {
+		// fetch jwks from clerk api
+		let jwks_model = Jwks::get_jwks(&self.clerk_client).await.map_err(|_| JwksProviderError::JwksApi)?;
+
+		// construct new state
+		let keys = jwks_model.keys.into_iter().map(|k| (k.kid.clone(), k)).collect();
+		let state = MemoryCacheJwksProviderState {
+			keys,
+			last_updated: SystemTime::now(),
+		};
+
+		Ok(Arc::new(state))
+	}
+}
+
+#[async_trait]
+impl JwksProvider for MemoryCacheJwksProvider {
+	type Error = JwksProviderError;
+
+	async fn get_key(&self, kid: &str) -> Result<JwksKey, Self::Error> {
+		// get the current cache state
+		let state = self.state.load();
+
+		// if the state is uninitialized or expired, refresh it
+		let mut refreshed = false;
+		let state = if state.is_uninitialized() || state.is_expired(self.options.expire_after) {
+			// attempt to refresh the jwks and store the new cache state
+			let new_state = self.refresh().await?;
+			self.state.swap(new_state.clone());
+			refreshed = true;
+			Guard::from_inner(new_state)
+		} else {
+			state
+		};
+
+		let maybe_key = state.keys.get(kid).cloned();
+
+		if let Some(key) = maybe_key {
+			// key found in cache
+			Ok(key)
+		} else {
+			// key not in cache, do stuff depending on refresh_on_unknown
+
+			// if we just refreshed, don't refresh again
+			if refreshed {
+				return Err(JwksProviderError::UnknownKey);
+			}
+
+			// if refresh_on_unknown is Never, just error
+			if let RefreshOnUnknown::Never = self.options.refresh_on_unknown {
+				return Err(JwksProviderError::UnknownKey);
+			}
+
+			// if refresh_on_unknown is Ratelimit and the cache is too new, error
+			if let RefreshOnUnknown::Ratelimit(min_age) = self.options.refresh_on_unknown {
+				if !state.is_expired(Some(min_age)) {
+					return Err(JwksProviderError::UnknownKey);
+				}
+			}
+
+			// ratelimit is not exceeded or refresh_on_unkown is Always, so refresh and store
+			let new_state = self.refresh().await?;
+			self.state.swap(new_state.clone());
+
+			// check if the new state has the key
+			new_state.keys.get(kid).cloned().ok_or(JwksProviderError::UnknownKey)
+		}
+	}
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+	use super::*;
+	use crate::apis::jwks_api::JwksKey;
+	use std::collections::HashMap;
+
+	pub struct StaticJwksProvider {
+		keys: HashMap<String, JwksKey>,
+	}
+
+	impl StaticJwksProvider {
+		pub fn from_key(key: JwksKey) -> Self {
+			let mut keys = HashMap::new();
+			keys.insert(key.kid.clone(), key);
+
+			Self { keys }
+		}
+	}
+
+	#[async_trait]
+	impl JwksProvider for StaticJwksProvider {
+		type Error = JwksProviderError;
+
+		async fn get_key(&self, kid: &str) -> Result<JwksKey, Self::Error> {
+			self.keys.get(kid).cloned().ok_or(JwksProviderError::UnknownKey)
+		}
+	}
+}

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -1,6 +1,8 @@
-// Validators for Rocket, etc coming very soon
 pub mod authorizer;
+pub mod jwks;
 
+// Framework-specific modules
+// Validators for Rocket, etc coming very soon
 #[cfg(feature = "actix")]
 pub mod actix;
 #[cfg(feature = "axum")]


### PR DESCRIPTION
This PR adds a `JwksProvider` trait which is used by `ClerkAuthorizer` to retrieve JWKs for validating requests.

It provides `SimpleJwksProvider` which reqeusts the JWKS from Clerk on every request, and `MemoryCacheJwksProvider` that caches the JWKS in memory. The expiration time of `MemoryCacheJwksProvider` is optional and configurable. The behavior when an key that isn't in the cache is requested is also configurable: don't refresh the JWKS, always refresh the JWKS, and refresh the JWKS if the cache is older than a certain duration.

This PR also splits `validate_jwt` into `validate_jwt` which takes a `JwksProvider` and `validate_jwt_with_key` which takes a `JwksKey`. The Axum and Actix middlewares are also updated to take a `JwksProvider` instead of a `ClerkConfiguration`.

Closes #45.