### PR TITLE
[feature] make sid optional

### DIFF
--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -12,7 +12,7 @@ pub struct ClerkJwt {
 	pub iat: i32,
 	pub iss: String,
 	pub nbf: i32,
-	pub sid: String,
+	pub sid: Option<String>,
 	pub sub: String,
 }
 


### PR DESCRIPTION
In doing some testing with [long lived tokens](https://clerk.com/docs/testing/postman-or-insomnia) I realized that `clerk-rs` expects the `sid` field to be present when decoding JWTs. However, long-lived template tokens don't appear to have that field on the payload. From jwt.io decoding of a long-lived token of mine:
<img width="142" alt="Screenshot 2024-06-03 at 8 04 27 AM" src="https://github.com/DarrenBaldwin07/clerk-rs/assets/11138157/8c7acf24-f08f-4260-a7a3-ca4d04912b95">

I propose making the `sid` field optional.
