### PR TITLE
[bug] make dynamic routes work properly

### DIFF
--- a/src/clerk.rs
+++ b/src/clerk.rs
@@ -123,7 +123,7 @@ impl Clerk {
 
 	/// Make a GET request with params to the specified Clerk API endpoint
 	pub async fn get_with_params(&self, endpoint: ClerkDynamicGetEndpoint, params: Vec<&str>) -> Result<serde_json::value::Value, reqwest::Error> {
-		let parsed_endpoint = endpoint.to_string();
+		let parsed_endpoint = endpoint.as_str();
 		let url = format!("{}{}", self.config.base_path, parsed_endpoint);
 		let url_with_params = generate_path_from_params(url, params);
 

--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -12,7 +12,7 @@ pub struct ClerkJwt {
 	pub iat: i32,
 	pub iss: String,
 	pub nbf: i32,
-	pub sid: String,
+	pub sid: Option<String>,
 	pub sub: String,
 }
 


### PR DESCRIPTION
`to_string` would result in a URL like `myclerkdomain.com/rest/v1GetUser` instead of the proper `myclerkdomain.com/rest/v1/user/{user_id}`. This uses the enum fn `as_str` to get the proper path for a given endpoint.

This PR stacks on https://github.com/DarrenBaldwin07/clerk-rs/pull/48