### PR TITLE
Make non-recommended JWT claims optional

### DIFF
--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -12,7 +12,7 @@ pub struct ClerkJwt {
 	pub iat: i32,
 	pub iss: String,
 	pub nbf: i32,
-	pub sid: String,
+	pub sid: Option<String>,
 	pub sub: String,
 }
 
@@ -111,7 +111,7 @@ pub fn validate_jwt(token: &str, jwks: JwksModel) -> Result<ClerkJwt, ClerkError
 
 				match decode::<ClerkJwt>(token, &decoding_key, &validation) {
 					Ok(token) => Ok(token.claims),
-					_ => Err(ClerkError::Unauthorized(String::from("Error: Invalid JWT!"))),
+					Err(err) => Err(ClerkError::Unauthorized(format!("Error: Invalid JWT! cause: {}", err))),
 				}
 			}
 			_ => Err(ClerkError::InternalServerError(String::from("Error: Unsupported key algorithm"))),


### PR DESCRIPTION
`sid` is not a recommended claim according to the guidelines (https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-token-claims). Recently, we encountered an issue where the server returned a 401 error because JSON parsing failed on a token that lacked `sid`.