### PR TITLE
Pass ClerkJWT

### DIFF
--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -5,7 +5,7 @@ use crate::{
 use jsonwebtoken::{decode, decode_header, errors::Error as jwtError, Algorithm, DecodingKey, Header, Validation};
 use std::{error::Error, fmt};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ActiveOrganization {
 	#[serde(rename = "org_id")]
 	pub id: String,
@@ -32,7 +32,7 @@ impl ActiveOrganization {
 	}
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ClerkJwt {
 	pub azp: Option<String>,
 	pub exp: i32,

--- a/src/validators/axum.rs
+++ b/src/validators/axum.rs
@@ -107,7 +107,7 @@ where
 		self.service.poll_ready(cx)
 	}
 
-	fn call(&mut self, request: Request) -> Self::Future {
+	fn call(&mut self, mut request: Request) -> Self::Future {
 		let mut svc = self.service.clone();
 
 		// We want to skip running the validator if we are not able to find a matching path from the listed valid paths provided by the user
@@ -137,7 +137,8 @@ where
 			// Check if the request is authenticated
 			match authorizer.authorize(&req).await {
 				// We have authed request and can pass the user onto the next body
-				Ok(_) => {
+				Ok(jwt) => {
+					request.extensions_mut().insert(jwt);
 					let res = svc.call(request).await?;
 					return Ok(res);
 				}


### PR DESCRIPTION
This PR passes the validated `ClerkJWT` so that it can be used in the routes by the `Extension` extractor: `Extension(jwt): Extension<ClerkJwt>`.