### PR TITLE
Include README in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["DarrenBaldwin07"]
 description = "The official community Rust SDK for the Clerk API"
 repository = "https://github.com/DarrenBaldwin07/clerk-rs"
 homepage = "https://github.com/DarrenBaldwin07/clerk-rs"
+readme = "README.md"
 keywords = ["clerk", "auth", "actix", "axum", "sdk"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
Minor change. This will render the `README.md` in the rustdocs when viewing them.

I was unsure if this was omitted intentionally by the maintainer, but seems like this would make the docs a bit more informative, since doc comments in the code are still a bit sparse.