### PR TITLE
Make fields of ActiveOrganization struct public

### DIFF
--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -8,13 +8,13 @@ use std::{error::Error, fmt};
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct ActiveOrganization {
 	#[serde(rename = "org_id")]
-	id: String,
+	pub id: String,
 	#[serde(rename = "org_slug")]
-	slug: String,
+	pub slug: String,
 	#[serde(rename = "org_role")]
-	role: String,
+	pub role: String,
 	#[serde(rename = "org_permissions")]
-	permissions: Vec<String>,
+	pub permissions: Vec<String>,
 }
 
 impl ActiveOrganization {


### PR DESCRIPTION
This is a followup to #56 to make the fields of `ActiveOrganization` public so that they can be accessed to get `org` information from a `ClerkJwt` struct. 

As far as I can tell this shouldn't require any updates to tests or documentation, but I'm happy to make updates as needed.