### PR TITLE
minor: Mark some structs as `Clone`

### DIFF
--- a/src/clerk.rs
+++ b/src/clerk.rs
@@ -9,32 +9,31 @@ use serde_json::Value;
 // Default user agent used for clerk-rs sdk (this is sent with every clerk api request)
 pub const USER_AGENT: &str = concat!("Clerk/v1 RustBindings/", env!("CARGO_PKG_VERSION"));
 
-/*
- * Unofficial Clerk SDK
- *
- * Please refer to the clerk.dev official documentation for more information: https://docs.clerk.dev
- *
- * # Examples
- * ```
- * use clerk_rs::Clerk;
- * use clerk_rs::apis::configuration::ClerkConfiguration;
- *
- * let config = ClerkConfiguration::new(None, None, Some("your_secret_key".to_owned()), None);
- * let client = Clerk::new(config);
- *
- * let res = client.get(ClerkGetEndpoint::GetUserList).await?;
- *
- * ```
- *
- * NOTE: This SDK is based on the official clerk openAPI spec found here: https://clerk.com/docs/reference/backend-api
- */
+/// Unofficial Clerk SDK
+///
+/// Please refer to the clerk.dev official documentation for more information: https://docs.clerk.dev
+///
+/// # Examples
+///
+/// ```rust
+/// use clerk_rs::Clerk;
+/// use clerk_rs::apis::configuration::ClerkConfiguration;
+///
+/// let config = ClerkConfiguration::new(None, None, Some("your_secret_key".to_owned()), None);
+/// let client = Clerk::new(config);
+///
+/// let res = client.get(ClerkGetEndpoint::GetUserList).await?;
+/// ```
+///
+/// **NOTE:** This SDK is based on the official clerk openAPI spec found here:
+/// https://clerk.com/docs/reference/backend-api
 #[derive(Clone)]
 pub struct Clerk {
 	pub config: configuration::ClerkConfiguration,
 }
 
 impl Clerk {
-	// Creates a new Clerk SDK client for making requests out to the public Clerk api:
+	/// Creates a new Clerk SDK client for making requests out to the public Clerk api.
 	pub fn new(clerk_configuration: configuration::ClerkConfiguration) -> Self {
 		Self { config: clerk_configuration }
 	}

--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -5,7 +5,7 @@ use crate::{
 use jsonwebtoken::{decode, decode_header, errors::Error as jwtError, Algorithm, DecodingKey, Header, Validation};
 use std::{error::Error, fmt};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ActiveOrganization {
 	#[serde(rename = "org_id")]
 	pub id: String,
@@ -32,7 +32,7 @@ impl ActiveOrganization {
 	}
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ClerkJwt {
 	pub azp: Option<String>,
 	pub exp: i32,
@@ -51,7 +51,7 @@ pub trait ClerkRequest {
 	fn get_cookie(&self, key: &str) -> Option<String>;
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ClerkError {
 	Unauthorized(String),
 	InternalServerError(String),


### PR DESCRIPTION
This may be useful for some users of the structs.

This change also transforms some documentation to Rust doc comments.