### PR TITLE
chore: Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,17 +37,17 @@ serde_derive = "^1.0"
 serde_with = "^2.0"
 serde_json = "^1.0"
 url = "^2.2"
-regex = "1.7.3"
-jsonwebtoken = "8.3.0"
+regex = "1.10.6"
+jsonwebtoken = "9.3.0"
 futures-util = "0.3.28"
-actix-rt = { version = "2.9.0", optional = true }
-actix-web = { version = "4.3.1", optional = true }
+actix-rt = { version = "2.10.0", optional = true }
+actix-web = { version = "4.9.0", optional = true }
 axum = { version = "0.7.5", optional = true }
 axum-extra = { version = "0.9.3", features = ["cookie"], optional = true }
-tower = { version = "0.4.13", optional = true }
+tower = { version = "0.5.0", optional = true }
 
 [dependencies.reqwest]
-version = "^0.11"
+version = "^0.12"
 default-features = false
 features = ["json", "multipart"]
 
@@ -56,7 +56,7 @@ base64 = "0.22.1"
 clerk-rs = { path = "../clerk-rs" }
 rand = "0.8.5"
 rsa = "0.9.6"
-tokio = { version = "1.27.0", features = ["full"] }
+tokio = { version = "1.39.3", features = ["full"] }
 
 [features]
 default = ["rustls-tls"]


### PR DESCRIPTION
This change bumps some of the old dependencies. I'm also happy to break this into a separate changes if so desired.

Notably, this bumps `reqwest` to a version that mitigates [RUSTSEC-2024-0336](https://rustsec.org/advisories/RUSTSEC-2024-0336).