### PR TITLE
Expose `ClerkAuthorizer::jwks_provider` publicly

### DIFF
--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -91,6 +91,11 @@ impl<J: JwksProvider> ClerkAuthorizer<J> {
 		}
 	}
 
+	/// Returns a reference to the underlying [`JwksProvider`].
+	pub fn jwks_provider(&self) -> &Arc<J> {
+		&self.jwks_provider
+	}
+
 	/// Authorizes a service request against the Clerk auth provider
 	pub async fn authorize<T>(&self, request: &T) -> Result<ClerkJwt, ClerkError>
 	where


### PR DESCRIPTION
This may be useful for people who may want to use it with `validate_jwt()`.