### PR TITLE
Update Create Organization Request

### DIFF
--- a/docs/CreateOrganizationRequest.md
+++ b/docs/CreateOrganizationRequest.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **public_metadata** | Option<[**serde_json::Value**](.md)> | Metadata saved on the organization, read-only from the Frontend API and fully accessible (read/write) from the Backend API | [optional]
 **slug** | Option<**String**> | A slug for the new organization. Can contain only lowercase alphanumeric characters and the dash \"-\". Must be unique for the instance. | [optional]
 **max_allowed_memberships** | Option<**i32**> | The maximum number of memberships allowed for this organization | [optional]
+**created-at** | Option<**String**> | A custom date/time denoting when the organization was created, specified in RFC3339 format (e.g. `2012-10-20T07:15:20.902Z`). | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/CreateOrganizationRequest.md
+++ b/docs/CreateOrganizationRequest.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **public_metadata** | Option<[**serde_json::Value**](.md)> | Metadata saved on the organization, read-only from the Frontend API and fully accessible (read/write) from the Backend API | [optional]
 **slug** | Option<**String**> | A slug for the new organization. Can contain only lowercase alphanumeric characters and the dash \"-\". Must be unique for the instance. | [optional]
 **max_allowed_memberships** | Option<**i32**> | The maximum number of memberships allowed for this organization | [optional]
-**created-at** | Option<**String**> | A custom date/time denoting when the organization was created, specified in RFC3339 format (e.g. `2012-10-20T07:15:20.902Z`). | [optional]
+**created-at** | Option<**String**> | A custom date/time denoting _when_ the organization was created, specified in RFC3339 format (e.g. `2012-10-20T07:15:20.902Z`). | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/CreateOrganizationRequest.md
+++ b/docs/CreateOrganizationRequest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **String** | The name of the new organization | 
-**created_by** | **String** | The ID of the User who will become the administrator for the new organization | 
+**created_by** | Option<**String**> | The ID of the User who will become the administrator for the new organization | [optional]
 **private_metadata** | Option<[**serde_json::Value**](.md)> | Metadata saved on the organization, accessible only from the Backend API | [optional]
 **public_metadata** | Option<[**serde_json::Value**](.md)> | Metadata saved on the organization, read-only from the Frontend API and fully accessible (read/write) from the Backend API | [optional]
 **slug** | Option<**String**> | A slug for the new organization. Can contain only lowercase alphanumeric characters and the dash \"-\". Must be unique for the instance. | [optional]

--- a/docs/OrganizationsApi.md
+++ b/docs/OrganizationsApi.md
@@ -19,7 +19,7 @@ Method | HTTP request | Description
 > crate::models::Organization create_organization(create_organization_request)
 Create an organization
 
-Creates a new organization with the given name for an instance. In order to successfully create an organization you need to provide the ID of the User who will become the organization administrator. You can specify an optional slug for the new organization. If provided, the organization slug can contain only lowercase alphanumeric characters (letters and digits) and the dash \"-\". Organization slugs must be unique for the instance. You can provide additional metadata for the organization and set any custom attribute you want. Organizations support private and public metadata. Private metadata can only be accessed from the Backend API. Public metadata can be accessed from the Backend API, and are read-only from the Frontend API.
+Creates a new organization with the given name for an instance. You can specify an optional slug for the new organization. If provided, the organization slug can contain only lowercase alphanumeric characters (letters and digits) and the dash \"-\". Organization slugs must be unique for the instance. You can provide additional metadata for the organization and set any custom attribute you want. Organizations support private and public metadata. Private metadata can only be accessed from the Backend API. Public metadata can be accessed from the Backend API, and are read-only from the Frontend API.
 
 ### Parameters
 

--- a/src/apis/organizations_api.rs
+++ b/src/apis/organizations_api.rs
@@ -84,7 +84,7 @@ pub enum UploadOrganizationLogoError {
 pub struct Organization;
 
 impl Organization {
-	/// Creates a new organization with the given name for an instance. In order to successfully create an organization you need to provide the ID of the User who will become the organization administrator. You can specify an optional slug for the new organization. If provided, the organization slug can contain only lowercase alphanumeric characters (letters and digits) and the dash \"-\". Organization slugs must be unique for the instance. You can provide additional metadata for the organization and set any custom attribute you want. Organizations support private and public metadata. Private metadata can only be accessed from the Backend API. Public metadata can be accessed from the Backend API, and are read-only from the Frontend API.
+	/// Creates a new organization with the given name for an instance. You can specify an optional slug for the new organization. If provided, the organization slug can contain only lowercase alphanumeric characters (letters and digits) and the dash \"-\". Organization slugs must be unique for the instance. You can provide additional metadata for the organization and set any custom attribute you want. Organizations support private and public metadata. Private metadata can only be accessed from the Backend API. Public metadata can be accessed from the Backend API, and are read-only from the Frontend API.
 	pub async fn create_organization(
 		clerk_client: &Clerk,
 		create_organization_request: Option<crate::models::CreateOrganizationRequest>,

--- a/src/models/create_organization_request.rs
+++ b/src/models/create_organization_request.rs
@@ -29,8 +29,8 @@ pub struct CreateOrganizationRequest {
 	#[serde(rename = "max_allowed_memberships", skip_serializing_if = "Option::is_none")]
 	pub max_allowed_memberships: Option<i64>,
 	/// A custom date/time denoting _when_ the organization was created, specified in RFC3339 format (e.g. `2012-10-20T07:15:20.902Z`).
-    #[serde(rename = "created_at", skip_serializing_if = "Option::is_none")]
-    pub created_at: Option<String>,
+	#[serde(rename = "created_at", skip_serializing_if = "Option::is_none")]
+	pub created_at: Option<String>,
 }
 
 impl CreateOrganizationRequest {

--- a/src/models/create_organization_request.rs
+++ b/src/models/create_organization_request.rs
@@ -28,7 +28,7 @@ pub struct CreateOrganizationRequest {
 	/// The maximum number of memberships allowed for this organization
 	#[serde(rename = "max_allowed_memberships", skip_serializing_if = "Option::is_none")]
 	pub max_allowed_memberships: Option<i64>,
-	/// A custom date/time denoting _when_ the organization was created, specified in RFC3339 format (e.g. `2012-10-20T07:15:20.902Z`).
+	/// A custom date/time denoting when the organization was created, specified in RFC3339 format (e.g. 2012-10-20T07:15:20.902Z).
 	#[serde(rename = "created_at", skip_serializing_if = "Option::is_none")]
 	pub created_at: Option<String>,
 }

--- a/src/models/create_organization_request.rs
+++ b/src/models/create_organization_request.rs
@@ -14,8 +14,8 @@ pub struct CreateOrganizationRequest {
 	#[serde(rename = "name")]
 	pub name: String,
 	/// The ID of the User who will become the administrator for the new organization
-	#[serde(rename = "created_by")]
-	pub created_by: String,
+	#[serde(rename = "created_by", skip_serializing_if = "Option::is_none")]
+	pub created_by: Option<String>,
 	/// Metadata saved on the organization, accessible only from the Backend API
 	#[serde(rename = "private_metadata", skip_serializing_if = "Option::is_none")]
 	pub private_metadata: Option<serde_json::Value>,
@@ -28,17 +28,21 @@ pub struct CreateOrganizationRequest {
 	/// The maximum number of memberships allowed for this organization
 	#[serde(rename = "max_allowed_memberships", skip_serializing_if = "Option::is_none")]
 	pub max_allowed_memberships: Option<i64>,
+	/// A custom date/time denoting _when_ the organization was created, specified in RFC3339 format (e.g. `2012-10-20T07:15:20.902Z`).
+    #[serde(rename = "created_at", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
 }
 
 impl CreateOrganizationRequest {
-	pub fn new(name: String, created_by: String) -> CreateOrganizationRequest {
+	pub fn new(name: String) -> CreateOrganizationRequest {
 		CreateOrganizationRequest {
 			name,
-			created_by,
+			created_by: None,
 			private_metadata: None,
 			public_metadata: None,
 			slug: None,
 			max_allowed_memberships: None,
+			created_at: None,
 		}
 	}
 }


### PR DESCRIPTION
Update the `CreateOrganizationRequest` model to match Clerk's backend API docs for creating an organization: https://clerk.com/docs/reference/backend-api/tag/Organizations#operation/CreateOrganization
- Allow organization creation without an assigned admin user by making the `created_by` field optional
- Allow custom creation timestamps when creating an organization by adding the optional `created_at` field

I've tested this in a separate project but let me know if there's somewhere that integration or other tests should be added.