### PR TITLE
Add Logging to middlewares using `tracing` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "The official community Rust SDK for the Clerk API"
 repository = "https://github.com/DarrenBaldwin07/clerk-rs"
 homepage = "https://github.com/DarrenBaldwin07/clerk-rs"
 readme = "README.md"
-keywords = ["clerk", "auth", "actix", "axum", "rocket"]
+keywords = ["clerk", "auth", "actix", "axum", "rocket", "tracing"]
 license = "MIT"
 edition = "2021"
 
@@ -33,6 +33,11 @@ name = "rocket"
 path = "examples/rocket.rs"
 required-features = ["rocket"]
 
+[[example]]
+name = "tracing"
+path = "examples/tracing.rs"
+required-features = ["tracing"]
+
 [lib]
 doctest = false
 
@@ -54,6 +59,8 @@ tower = { version = "0.5.0", optional = true }
 async-trait = "0.1.81"
 arc-swap = "1.7.1"
 poem = { version = "3", features = ["cookie"], optional = true }
+tracing = { version = "^0.1.41", optional = true }
+tracing-subscriber = { version = "0.3", features = ["fmt"], default-features = false }
 
 [dependencies.reqwest]
 version = "^0.12"
@@ -76,3 +83,4 @@ actix = ["dep:actix-rt", "dep:actix-web"]
 axum = ["dep:axum", "dep:axum-extra", "dep:tower"]
 rocket = ["dep:rocket"]
 poem = ["dep:poem"]
+tracing = ["dep:tracing"]

--- a/examples/tracing_axum.rs
+++ b/examples/tracing_axum.rs
@@ -1,0 +1,38 @@
+use axum::{routing::get, Extension, Router};
+use clerk_rs::{
+	clerk::Clerk,
+	validators::{authorizer::ClerkJwt, axum::ClerkLayer, jwks::MemoryCacheJwksProvider},
+	ClerkConfiguration,
+};
+
+async fn index() -> &'static str {
+	"Hello world! This is an unprotected route!"
+}
+
+/// This route can retrieve the user's authentication information using the Extension<ClerkJwt> extractor.
+/// Note: If you use this extractor on an unauthenticated route, you will hit a runtime error.
+async fn protected_route(Extension(clerk_jwt): Extension<ClerkJwt>) -> String {
+    format!("Hello, user with id {}! This is a protected route, you had to be authorized to get this!", clerk_jwt.sub)
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+
+    // Use a basic tracing_subscriber to print logs to the console.
+    tracing_subscriber::fmt::init();
+
+    // Paste your secret key over 'your_secret_key'.
+    // Do note: if building a real project, you should never put secrets inside code source.
+    // Consider storing secrets in environmental variables instead.
+	let config = ClerkConfiguration::new(None, None, Some("your_secret_key".to_string()), None);
+	let clerk = Clerk::new(config);
+
+	let app = Router::new()
+        .route("/", get(index))
+        .route("/index", get(index))
+        .route("/user", get(protected_route))
+        .layer(ClerkLayer::new(MemoryCacheJwksProvider::new(clerk), Some(vec![String::from("/user")]), true));
+
+	let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
+	axum::serve(listener, app).await
+}

--- a/src/validators/actix.rs
+++ b/src/validators/actix.rs
@@ -106,16 +106,15 @@ where
 
 	forward_ready!(service);
 
-	#[cfg(feature="tracing")]
-	#[tracing::instrument(
+	#[cfg_attr(feature = "tracing", tracing::instrument(
 		skip_all, 
-		name="clerk_actix_middleware", 
+		name = "clerk_actix_middleware", 
 		fields(
 			request.uri = request.uri().to_string(),
 			request.method = request.method().as_str(),
-			// Unlike other libraries, axum only includes connection info via an extension.
+			// Unlike other libraries, actix only includes connection info via an extension.
 		)
-	)]
+	))]
 	fn call(&self, request: ServiceRequest) -> Self::Future {
 
 		#[cfg(feature="tracing")]

--- a/src/validators/axum.rs
+++ b/src/validators/axum.rs
@@ -118,7 +118,21 @@ where
 		self.service.poll_ready(cx)
 	}
 
+	#[cfg(feature="tracing")]
+	#[tracing::instrument(
+		skip_all, 
+		name="clerk_axum_middleware", 
+		fields(
+			request.uri = request.uri().to_string(),
+			request.method = request.method().as_str()
+			// Unlike other libraries, axum only includes connection info via an extension.
+		)
+	)]
 	fn call(&mut self, mut request: Request) -> Self::Future {
+		
+		#[cfg(feature="tracing")]
+		tracing::trace!("Auth middleware entered");
+		
 		let mut svc = self.service.clone();
 
 		// We want to skip running the validator if we are not able to find a matching path from the listed valid paths provided by the user
@@ -133,6 +147,13 @@ where
 					// Since the path was not inside of the listed routes we want to trigger an early exit
 					return Box::pin(async move {
 						let res = svc.call(request).await?;
+						
+						#[cfg(feature="tracing")]
+						tracing::info!("Route excluded from auth, skipping auth.");
+
+						#[cfg(feature="tracing")]
+						tracing::trace!("Auth middleware exited");
+						
 						return Ok(res);
 					});
 				}
@@ -149,17 +170,39 @@ where
 			match authorizer.authorize(&req).await {
 				// We have authed request and can pass the user onto the next body
 				Ok(jwt) => {
+
+					#[cfg(feature="tracing")]
+					tracing::info!("Authed request; user is: {}", &jwt.sub);
+
 					request.extensions_mut().insert(jwt);
 					let res = svc.call(request).await?;
+
+					#[cfg(feature="tracing")]
+					tracing::trace!("Auth middleware exited");
+					
 					return Ok(res);
 				}
 				// Output any other errors thrown from the Clerk authorizer
 				Err(error) => {
 					match error {
 						ClerkError::Unauthorized(msg) => {
+							
+							#[cfg(feature="tracing")]
+							tracing::info!("Middleware blocked unauthorized: {}", &msg);
+
+							#[cfg(feature="tracing")]
+							tracing::trace!("Auth middleware exited");
+							
 							return Ok(Response::builder().status(StatusCode::UNAUTHORIZED).body(Body::from(msg)).unwrap())
 						}
 						ClerkError::InternalServerError(msg) => {
+							
+							#[cfg(feature="tracing")]
+							tracing::error!("Internal Server Error with auth middleware: {}", &msg);
+
+							#[cfg(feature="tracing")]
+							tracing::trace!("Auth middleware exited");
+							
 							return Ok(Response::builder()
 								.status(StatusCode::INTERNAL_SERVER_ERROR)
 								.body(Body::from(msg))

--- a/src/validators/axum.rs
+++ b/src/validators/axum.rs
@@ -118,16 +118,15 @@ where
 		self.service.poll_ready(cx)
 	}
 
-	#[cfg(feature="tracing")]
-	#[tracing::instrument(
+	#[cfg_attr(feature = "tracing", tracing::instrument(
 		skip_all, 
-		name="clerk_axum_middleware", 
+		name = "clerk_axum_middleware", 
 		fields(
 			request.uri = request.uri().to_string(),
 			request.method = request.method().as_str()
 			// Unlike other libraries, axum only includes connection info via an extension.
 		)
-	)]
+	))]
 	fn call(&mut self, mut request: Request) -> Self::Future {
 		
 		#[cfg(feature="tracing")]

--- a/src/validators/poem.rs
+++ b/src/validators/poem.rs
@@ -64,16 +64,15 @@ where
 {
 	type Output = Response;
 
-	#[cfg(feature="tracing")]
-	#[tracing::instrument(
+	#[cfg_attr(feature = "tracing", tracing::instrument(
 		skip_all, 
-		name="clerk_poem_middleware", 
+		name = "clerk_poem_middleware", 
 		fields(
 			req.remote_addr = req.remote_addr().to_string(), 
 			req.uri = req.uri().to_string(),
 			req.method = req.method().to_string()
 		)
-	)]
+	))]
 	async fn call(&self, mut req: Request) -> Result<Self::Output> {
 		
 		#[cfg(feature="tracing")]
@@ -110,20 +109,20 @@ where
 			}
 			Err(error) => match &error {
 				// The error strings are passed through with the correct status code
-				ClerkError::Unauthorized(msg) => {
-					
+				ClerkError::Unauthorized(_msg) => {
+
 					#[cfg(feature="tracing")]
-					tracing::info!("Middleware blocked unauthorized: {}", &msg);
+					tracing::info!("Middleware blocked unauthorized: {}", &_msg);
 					
 					#[cfg(feature="tracing")]
 					tracing::trace!("Auth middleware exited");
 
 					Err(Unauthorized(error))
 				},
-				ClerkError::InternalServerError(msg) => {
+				ClerkError::InternalServerError(_msg) => {
 					
 					#[cfg(feature="tracing")]
-					tracing::error!("Internal Server Error with auth middleware: {}", &msg);
+					tracing::error!("Internal Server Error with auth middleware: {}", &_msg);
 
 					#[cfg(feature="tracing")]
 					tracing::trace!("Auth middleware exited");

--- a/src/validators/rocket.rs
+++ b/src/validators/rocket.rs
@@ -43,10 +43,10 @@ pub struct ClerkGuard<J: JwksProvider + Send + Sync> {
 impl<'r, J: JwksProvider + Send + Sync + 'static> FromRequest<'r> for ClerkGuard<J> {
 	type Error = ClerkError;
 
-	#[cfg(feature="tracing")]
-	#[tracing::instrument(
+	
+	#[cfg_attr(feature = "tracing", tracing::instrument(
 		skip_all, 
-		name="clerk_rocket_middleware", 
+		name = "clerk_rocket_middleware", 
 		fields(
 			request.remote = match request.remote() {
 				Some(val) => val.to_string(),
@@ -55,7 +55,7 @@ impl<'r, J: JwksProvider + Send + Sync + 'static> FromRequest<'r> for ClerkGuard
 			request.uri = request.uri().to_string(),
 			request.method = request.method().as_str()
 		)
-	)]
+	))]
 	async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
 		
 		#[cfg(feature="tracing")]


### PR DESCRIPTION
EDIT: This PR is mutually exclusive with #83. Accept one, reject the other.

I know I said I had a busy week. I guess it turned out to be several busy months!

This is my first stab at adding logging to this package. When the `tracing` feature is enabled, the appropriate middleware functions are instrumented and logging is inserted.

I decided to add the logging to the middleware instead of the inner authorizer or jwks code. I thought that most people wouldn't be interested in anything lower level, especially when the middlewares bubble up errors. Let me know if you think I am horribly misguided; this is my first time doing logging at a library level rather than an application level.

Resolves #71 