### PR TITLE
Feat/dynamic path matching and wildcard path matching support

### DIFF
--- a/src/validators/axum.rs
+++ b/src/validators/axum.rs
@@ -46,6 +46,9 @@ impl ClerkRequest for AxumClerkRequest {
 
 /// Axum layer for protecting a http endpoint with Clerk.dev.
 ///
+/// Supports dynamic path matching using curly braces syntax (e.g., `/api/users/{user_id}`).
+/// When specifying routes, you can use dynamic segments that will match any non-empty path segment.
+///
 /// # Example
 /// ```
 /// async fn index() -> &'static str {
@@ -57,9 +60,16 @@ impl ClerkRequest for AxumClerkRequest {
 ///     let config = ClerkConfiguration::new(None, None, Some("your_secret_key".to_string()), None);
 ///     let clerk = Clerk::new(config);
 ///
+///     // Protect specific routes, including dynamic paths
+///     let protected_routes = vec![
+///         "/api/users".to_string(),
+///         "/api/users/{user_id}".to_string(),
+///         "/api/users/{user_id}/profile".to_string(),
+///     ];
+///
 ///     let app = Router::new()
 ///         .route("/index", get(index))
-///         .layer(ClerkLayer::new(MemoryCacheJwksProvider::new(clerk), None, true));
+///         .layer(ClerkLayer::new(MemoryCacheJwksProvider::new(clerk), Some(protected_routes), true));
 ///
 ///     let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
 ///     axum::serve(listener, app).await


### PR DESCRIPTION
## Summary

  - Add dynamic path matching support to Axum middleware using {key} syntax for single path segments
  - Add wildcard path matching support using {*key} syntax for capturing multiple path segments
  - Update comprehensive documentation with examples for both dynamic segments and wildcards

* The same feature is already implemented in axum, and I believe it is essential for using axum and clerk together.
Ref: https://docs.rs/axum/latest/axum/routing/struct.Router.html

## Features Added

  - Dynamic Path Matching: {key} syntax matches single path segments (e.g., /api/users/{user_id})
  - Wildcard Matching: {*key} syntax captures all remaining path segments (must be last segment)
  - Mixed Patterns: Support for combining static paths, dynamic segments, and wildcards
  - Proper Validation: Both features include empty segment validation and comprehensive error handling

## Examples

### Dynamic Segments

  - /api/users/{user_id} matches /api/users/123
  - /api/users/{user_id}/profile matches /api/users/123/profile

### Wildcards

  - /{*key} matches /a, /a/b/c but not / (empty)
  - /assets/{*path} matches /assets/css/main.css, /assets/js/app.js
  - /{id}/{repo}/{*tree} matches /user123/my-repo/src/main.rs

## Test Plan

  - Comprehensive test suite covering both dynamic and wildcard matching
  - Edge case validation for empty segments
  - All existing tests continue to pass

## Related Issue
https://github.com/DarrenBaldwin07/clerk-rs/issues/118