### PR TITLE
fix: Support `unverified` email address variant

### DIFF
--- a/src/models/email_address_verification.rs
+++ b/src/models/email_address_verification.rs
@@ -36,6 +36,8 @@ impl EmailAddressVerification {
 pub enum Status {
 	#[serde(rename = "verified")]
 	Verified,
+	#[serde(rename = "unverified")]
+	Unverified,
 	#[serde(rename = "expired")]
 	Expired,
 	#[serde(rename = "failed")]


### PR DESCRIPTION
This can occur when verification is disabled.