### PR TITLE
feat: Support JWT v2 format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_derive = "^1.0"
 serde_with = "^2.0"
 serde_json = "^1.0"
+serde-aux = { version= "4.7.0", default-features = false }
 url = "^2.2"
 regex = "1.10.6"
 jsonwebtoken = "9.3.0"

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -1,7 +1,7 @@
 use axum::{routing::get, Extension, Router};
 use clerk_rs::{
 	clerk::Clerk,
-	validators::{authorizer::ClerkJwtV1, axum::ClerkLayer, jwks::MemoryCacheJwksProvider},
+	validators::{authorizer::ClerkJwt, axum::ClerkLayer, jwks::MemoryCacheJwksProvider},
 	ClerkConfiguration,
 };
 
@@ -14,8 +14,8 @@ async fn index() -> &'static str {
 /// ClerkJwt using an Extension extractor like so. Make sure you only
 /// use this extractor on protected routes, or else you will get a
 /// runtime error.
-async fn profile(Extension(clerk_jwt): Extension<ClerkJwtV1>) -> String {
-	format!("Hello, {}! This is an example of a protected route.", clerk_jwt.sub)
+async fn profile(Extension(clerk_jwt): Extension<ClerkJwt>) -> String {
+	format!("Hello, {}! This is an example of a protected route.", clerk_jwt.sub())
 }
 
 #[tokio::main]

--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -73,6 +73,81 @@ pub enum ClerkJwt {
 	V1(ClerkJwtV1),
 }
 
+impl ClerkJwt {
+	/// The Origin header that was included in the original Frontend API request made from the user.
+	/// Most commonly, it will be the URL of the application. This claim could be omitted if,
+	/// for privacy-related reasons, `Origin` is empty or null.
+	pub fn azp(&self) -> Option<&str> {
+		match self {
+			ClerkJwt::V2(jwt) => jwt.azp.as_deref(),
+			ClerkJwt::V1(jwt) => jwt.azp.as_deref(),
+		}
+	}
+
+	/// The time after which the token will expire, as a Unix timestamp.
+	/// Determined using the Token lifetime JWT template setting in the [Clerk Dashboard].
+	///
+	/// [Clerk Dashboard]: https://dashboard.clerk.com/~/jwt-templates
+	pub fn exp(&self) -> i64 {
+		match self {
+			ClerkJwt::V2(jwt) => jwt.exp,
+			ClerkJwt::V1(jwt) => jwt.exp,
+		}
+	}
+
+	/// The time at which the token was issued as a Unix timestamp.
+	pub fn iat(&self) -> i64 {
+		match self {
+			ClerkJwt::V2(jwt) => jwt.iat,
+			ClerkJwt::V1(jwt) => jwt.iat,
+		}
+	}
+
+	/// The Frontend API URL of your instance.
+	pub fn iss(&self) -> &str {
+		match self {
+			ClerkJwt::V2(jwt) => &jwt.iss,
+			ClerkJwt::V1(jwt) => &jwt.iss,
+		}
+	}
+
+	/// The time before which the token is considered invalid, as a Unix timestamp.
+	/// Determined using the Allowed Clock Skew JWT template setting in the [Clerk Dashboard].
+	///
+	/// [Clerk Dashboard]: https://dashboard.clerk.com/~/jwt-templates
+	pub fn nbf(&self) -> i64 {
+		match self {
+			ClerkJwt::V2(jwt) => jwt.nbf,
+			ClerkJwt::V1(jwt) => jwt.nbf,
+		}
+	}
+
+	/// The ID of the current session.
+	pub fn sid(&self) -> Option<&str> {
+		match self {
+			ClerkJwt::V2(jwt) => jwt.sid.as_deref(),
+			ClerkJwt::V1(jwt) => jwt.sid.as_deref(),
+		}
+	}
+
+	/// The ID of the current user of the session.
+	pub fn sub(&self) -> &str {
+		match self {
+			ClerkJwt::V2(jwt) => &jwt.sub,
+			ClerkJwt::V1(jwt) => &jwt.sub,
+		}
+	}
+
+	/// Catch-all for any other attributes that may be present in the JWT. This
+	/// is useful for custom templates that may have additional fields.
+	pub fn other(&self) -> &Map<String, Value> {
+		match self {
+			ClerkJwt::V2(jwt) => &jwt.other,
+			ClerkJwt::V1(jwt) => &jwt.other,
+		}
+	}
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ClerkJwtV1 {
 	pub azp: Option<String>,
@@ -229,10 +304,10 @@ impl<J: JwksProvider> ClerkAuthorizer<J> {
 		// get the jwt from header or cookies
 		let access_token: String = match request.get_header("Authorization") {
 			Some(val) => val.to_string().replace("Bearer ", ""),
-			None => match self.validate_session_cookie {
+			_ => match self.validate_session_cookie {
 				true => match request.get_cookie("__session") {
 					Some(cookie) => cookie.to_string(),
-					None => {
+					_ => {
 						return Err(ClerkError::Unauthorized(String::from(
 							"Error: No Authorization header or session cookie found on the request payload!",
 						)))

--- a/src/validators/axum.rs
+++ b/src/validators/axum.rs
@@ -1,5 +1,5 @@
 use crate::validators::{
-	authorizer::{ClerkAuthorizer, ClerkError, ClerkRequest},
+	authorizer::{ClerkAuthorizer, ClerkError, ClerkJwt, ClerkRequest},
 	jwks::JwksProvider,
 };
 use axum::{
@@ -146,7 +146,7 @@ where
 
 		Box::pin(async move {
 			// Check if the request is authenticated
-			match authorizer.authorize(&req).await {
+			match authorizer.authorize::<_, ClerkJwt>(&req).await {
 				// We have authed request and can pass the user onto the next body
 				Ok(jwt) => {
 					request.extensions_mut().insert(jwt);

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -7,7 +7,7 @@ pub mod jwks;
 pub mod actix;
 #[cfg(feature = "axum")]
 pub mod axum;
-#[cfg(feature = "rocket")]
-pub mod rocket;
 #[cfg(feature = "poem")]
 pub mod poem;
+#[cfg(feature = "rocket")]
+pub mod rocket;

--- a/src/validators/rocket.rs
+++ b/src/validators/rocket.rs
@@ -8,7 +8,7 @@ use rocket::{
 	Request,
 };
 
-use super::authorizer::ClerkJwt;
+use super::authorizer::ClerkJwtV1;
 
 // Implement ClerkRequest for Rocket's Request
 impl<'r> ClerkRequest for &'r Request<'_> {
@@ -34,7 +34,7 @@ impl<J: JwksProvider> ClerkGuardConfig<J> {
 }
 
 pub struct ClerkGuard<J: JwksProvider + Send + Sync> {
-	pub jwt: Option<ClerkJwt>,
+	pub jwt: Option<ClerkJwtV1>,
 	_marker: std::marker::PhantomData<J>,
 }
 


### PR DESCRIPTION
This is a proof-of-concept for supporting Clerk's JWT v2.

This is a breaking change.

cc @DarrenBaldwin07 for comment on the approach

Related: #109 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public API for JWT claim access and deserialization shapes across auth middleware; incorrect v1/v2 tagging could reject or mis-parse tokens in production.
> 
> **Overview**
> Adds **Clerk JWT v2** support alongside v1 by turning `ClerkJwt` into a versioned enum (`V2` when claim `v` is `2`, otherwise untagged `V1` via `ClerkJwtV1`), with shared accessors like `sub()` instead of reading fields directly.
> 
> Introduces v2-specific types (`ClerkJwtV2`, `ActiveOrganizationV2`) including plan/feature claims and `permissions_iter()` over feature-permission bitmasks; v1 claims move to `ClerkJwtV1` with `exp`/`iat`/`nbf` as `i64`. JWT validation and `ClerkAuthorizer::authorize` are now **generic** over any `DeserializeOwned` claims type.
> 
> **Axum** middleware decodes into the `ClerkJwt` union; the **axum example** uses `clerk_jwt.sub()`. **Rocket** guard types still expose `ClerkJwtV1` only. Adds **`serde-aux`** for claims that may arrive as a string or JSON array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 648c4d0f4b3c1c126a3c55be7ba568a19c799b38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->