### PR TITLE
fix: make nbf claim optional to support M2M JWTs

### DIFF
--- a/src/validators/authorizer.rs
+++ b/src/validators/authorizer.rs
@@ -43,7 +43,7 @@ pub struct ClerkJwt {
 	pub exp: i32,
 	pub iat: i32,
 	pub iss: String,
-	pub nbf: i32,
+	pub nbf: Option<i32>,
 	pub sid: Option<String>,
 	pub sub: String,
 	pub act: Option<Actor>,
@@ -311,7 +311,7 @@ mod tests {
 			iat: current_time as i32,
 			exp: (current_time + 1000) as i32,
 			iss: "issuer".to_string(),
-			nbf: current_time as i32,
+			nbf: Some(current_time as i32),
 			sid: Some("session_id".to_string()),
 			act: Some(Actor {
 				iss: Some("actor_iss".to_string()),
@@ -464,7 +464,7 @@ mod tests {
 			iat: current_time as i32,
 			exp: (current_time + 1000) as i32,
 			iss: "issuer".to_string(),
-			nbf: current_time as i32,
+			nbf: Some(current_time as i32),
 			sid: Some("session_id".to_string()),
 			act: Some(Actor {
 				iss: Some("actor_iss".to_string()),


### PR DESCRIPTION
Clerk's M2M ([ref](https://clerk.com/docs/reference/backend-api/2025-11-10/tag/m2m-tokens)) JWTs do not include the `nbf` claim. Because `ClerkJwt.nbf` was typed as `i32` (required), verifying an M2M JWT would crash at deserialization even though the signature is valid.

This PR change `nbf` from `i32` to `Option<i32>`.

Session JWTs from Clerk include `nbf` and are unaffected by this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JWT claim deserialization in the authorization path; while the change is small, it affects which tokens are accepted and could impact auth behavior if downstream code assumed `nbf` was always present.
> 
> **Overview**
> Updates the `ClerkJwt` claims struct to treat the `nbf` (not-before) claim as optional (`Option<i32>`) so JWTs that omit `nbf` (e.g., Clerk M2M tokens) can be deserialized and validated instead of failing.
> 
> Adjusts the related test expectations to use `nbf: Some(...)` when asserting decoded session tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d6b52de175848d9a943575a6a6b7c8881cec91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->