### PR TITLE
Upgrade jsonwebtoken to 10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde_derive = "^1.0"
 serde_json = "^1.0"
 url = "^2.2"
 regex = "1.10.6"
-jsonwebtoken = "9.3.0"
+jsonwebtoken = { version = "10.4.0", default-features = false, features = ["use_pem", "rust_crypto"] }
 futures-util = "0.3.28"
 actix-rt = { version = "2.10.0", optional = true }
 actix-web = { version = "4.9.0", optional = true }


### PR DESCRIPTION
## Summary
- upgrade jsonwebtoken from 9.3 to 10.4
- disable jsonwebtoken default features and keep PEM support explicit
- add Clerk feature flags for jsonwebtoken provider selection: `rust-crypto` by default, and `aws-lc-rs` for consumers that want AWS-LC
- consumers selecting `aws-lc-rs` should use `default-features = false` and enable `aws-lc-rs` plus their desired TLS/framework features, because jsonwebtoken automatic provider selection expects exactly one crypto provider
- avoids jsonwebtoken's old ring-backed path while preserving out-of-the-box JWT validation

## Testing
- cargo test
- cargo check --lib --no-default-features --features rustls-tls,aws-lc-rs
- cargo check --lib --no-default-features --features aws-lc-rs
- cargo tree --no-default-features --features aws-lc-rs -e features,no-dev -i jsonwebtoken
- cargo tree --no-default-features --features aws-lc-rs -e normal,build -i ring